### PR TITLE
remove fs from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   },
   "homepage": "https://github.com/falsisdev/falsisdb#readme",
   "dependencies": {
-    "fs": "^0.0.1-security",
     "events": "^3.3.0"
   },
   "devDependencies": {},


### PR DESCRIPTION
fs is an alredy built-in node.js module:https://www.w3schools.com/nodejs/ref_fs.asp